### PR TITLE
ci: validate renovate config

### DIFF
--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -1,5 +1,8 @@
 ---
-on: [push]
+name: Validate renovate config
+
+on:
+  - push
 
 jobs:
   validate-renovate-config:

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: renovate/renovate:slim
+      options: --user root
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - run: renovate --version

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - run: renovate --version
-      - run: renovate-config-validator
+      - run: renovate-config-validator default.json5

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -1,0 +1,13 @@
+---
+on: [push]
+
+jobs:
+  validate-renovate-config:
+    name: Validate renovate config
+    runs-on: ubuntu-latest
+    container:
+      image: renovate/renovate:slim
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - run: renovate --version
+      - run: renovate-config-validator


### PR DESCRIPTION
Use `renovate-config-validator` to validate the config, see https://docs.renovatebot.com/config-validation/#config-validation for more info.

Need to run as root in renovate image because of https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user